### PR TITLE
Timing requirement fix for arduino core 2.x+

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ Smart PHC controller with PHC-Modules. A close up of the board containing the ES
 
 # Requirements
 
-ESPHome 2022.11 or lower (see timing requirements).
-
 This project has been developed and tested on a ESP32. A ESP8266 is probably going to work just fine.
 
 The PHC-Bus is RS-485 based. In order communicate on the bus a RS-485 TTL Adapter is required. Currently only a Chip with automatic flow control has been tested.
@@ -18,25 +16,7 @@ Finally connect the RS-485 adapter to your ESP and you are good to go.
 
 With the help of a step-down module/voltage converter the 24V supplied by the PHC-power-supply can be used to power the ESP.
 
-Make sure to remove any 
-existing controllers (STM - Steuermodul) from the bus, as they will interfere. 
-
-# Timing requirements
-The original PHC implementation sends acknowledgement messages with a `250us` delay. This component implements the same delay.
-On ESPHome versions prior to 2022.12 this does work. With the help of an oscilloscope you can verify the delay. ESPHome versions newer than 2022.11 increase the delay, rendering the system almost unusable. The specific reason for this problem is not yet known.
-
-On newer ESPHome versions one possible workaround is to use an older version of the Arduino framework.
-This can be achieved by adding the following version and platform version to the configuration file.
-
-```yaml
-esp32:
-  board: esp32dev
-  framework:
-    type: arduino
-    # The timing is incorrect on new arduino versions or IDF based firmware
-    version: 1.0.6
-    platform_version: 3.5.0
-```
+Make sure to remove any existing controllers (STM - Steuermodul) from the bus, as they will interfere.
 
 # Configuration variables
 

--- a/components/AMD/switch.py
+++ b/components/AMD/switch.py
@@ -1,4 +1,3 @@
-from typing_extensions import Required
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import switch, light

--- a/components/EMD/binary_sensor.py
+++ b/components/EMD/binary_sensor.py
@@ -1,4 +1,3 @@
-from typing_extensions import Required
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import binary_sensor

--- a/components/PHCController/PHCController.h
+++ b/components/PHCController/PHCController.h
@@ -11,7 +11,8 @@
 #define FLOW_PIN_PULL_HIGH_DELAY 0
 #define FLOW_PIN_PULL_LOW_DELAY 0
 
-#define TIMING_DELAY 250 // 250us on original PHC
+#define TIMING_DELAY 150 // 250us on original PHC
+// This value has been adjusted, such that the measured delay is roughly equal to 250us. This has changed with arduino core 2.0+
 #define INITIAL_SYNC_DELAY 15
 
 namespace esphome

--- a/components/PHCController/__init__.py
+++ b/components/PHCController/__init__.py
@@ -1,4 +1,3 @@
-from typing_extensions import Required
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import pins

--- a/example.yaml
+++ b/example.yaml
@@ -5,9 +5,6 @@ esp32:
   board: esp32dev
   framework:
     type: arduino
-    # The timing is incorrect on new arduino versions or IDF based firmware
-    version: 1.0.6
-    platform_version: 3.5.0
 
 # Load components via Github
 external_components:


### PR DESCRIPTION
This pull request fixes the timing requirement issue indroduced by new arduino core versions. Previously, using an older arduino version was a valid solution to the problem, but recent ESPHome updates resulted in compilation issues.
This implementation fixes this timing issue and compilation issues. The response time has been adjusted, such that it is equal to the one measured on the original PHC system.